### PR TITLE
Fix issue routing

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -23,30 +23,35 @@ const routes: Routes = [
       {
         path: 'projects/:id',
         children: [
-          { path: '', pathMatch: 'full', component: ProjectOverviewComponent},
-          { path: 'graph', component: IssueGraphControlsComponent},
-          { path: 'issues',
-          children: [{ path: '', pathMatch: 'full', component: ProjectIssueListComponent},
-                     { path: 'component/:componentId/issue/:issueId', pathMatch: 'full', component: IssueDetailComponent},
-                    ]},
-          { path: 'members', component: ProjectMembersComponent},
-          { path: 'component/:componentId',
+          { path: '', pathMatch: 'full', component: ProjectOverviewComponent },
+          { path: 'graph', component: IssueGraphControlsComponent },
+          {
+            path: 'issues',
             children: [
-              { path: 'interface/:interfaceId',
+              { path: '', pathMatch: 'full', component: ProjectIssueListComponent },
+              { path: ':issueId', pathMatch: 'full', component: IssueDetailComponent },
+            ]
+          },
+          { path: 'members', component: ProjectMembersComponent },
+          {
+            path: 'component/:componentId',
             children: [
-              {path: '', pathMatch: 'full', component: InterfaceDetailsComponent, data: { animation: 'isRight' }},
-              {path: 'issue/:issueId', pathMatch: 'full', component: IssueDetailComponent},
-              {path: 'component/:componentId/issue/:issueId', pathMatch: 'full', component: IssueDetailComponent}
-            ]},
-              {path: '', pathMatch: 'full', component: ComponentDetailsComponent, data: { animation: 'isRight' }},
-              {path: 'issue/:issueId', pathMatch: 'full', component: IssueDetailComponent}
-            ]},
-          { path: 'interface/:interfaceId',
+              { path: '', pathMatch: 'full', component: ComponentDetailsComponent, data: { animation: 'isRight' } },
+              {
+                path: 'interface/:interfaceId',
+                children: [
+                  { path: '', pathMatch: 'full', component: InterfaceDetailsComponent, data: { animation: 'isRight' } },
+                  { path: 'component/:componentId/issue/:issueId', pathMatch: 'full', component: IssueDetailComponent }
+                ]
+              },
+            ]
+          },
+          {
+            path: 'interface/:interfaceId',
             children: [
-              {path: '', pathMatch: 'full', component: InterfaceDetailsComponent, data: { animation: 'isRight' }},
-              {path: 'issue/:issueId', pathMatch: 'full', component: IssueDetailComponent},
-              {path: 'component/:componentId/issue/:issueId', pathMatch: 'full', component: IssueDetailComponent}
-            ]}
+              { path: '', pathMatch: 'full', component: InterfaceDetailsComponent, data: { animation: 'isRight' } },
+            ]
+          }
         ]
       },
       { path: 'issue', component: IssueDetailComponent },
@@ -63,4 +68,5 @@ const routes: Routes = [
   imports: [RouterModule.forRoot(routes)],
   exports: [RouterModule]
 })
-export class AppRoutingModule { }
+export class AppRoutingModule {
+}

--- a/src/app/data-dgql/load.ts
+++ b/src/app/data-dgql/load.ts
@@ -13,6 +13,7 @@ type NodeQueries = {
 
 const nodeQueries: NodeQueries = {
   [NodeType.Project]: (i, id) => i.q.projects.getProject(id).then(data => data.node),
+  [NodeType.Component]: (i, id) => i.q.components.getComponent(id).then(data => data.node),
   [NodeType.Issue]: (i, id) => i.q.issues.getIssueHeader(id).then(data => data.node),
 };
 

--- a/src/app/data-dgql/queries/components.graphql
+++ b/src/app/data-dgql/queries/components.graphql
@@ -16,6 +16,14 @@ fragment fComponentStub on Component {
   }
 }
 
+fragment fInterfaceStub on ComponentInterface {
+  id
+  type
+  name
+  description
+  lastUpdatedAt
+}
+
 query ListProjectComponents($project: ID!, $after: String, $before: String, $filterBy: ComponentFilter, $first: Int, $last: Int) {
   node(id: $project) {
     ...on Project {
@@ -45,6 +53,67 @@ query GetComponent($id: ID!) {
   node(id: $id) {
     ...on Component {
       ...fComponentStub
+    }
+  }
+}
+
+query ListComponentInterfaces($component: ID!, $after: String, $before: String, $filterBy: ComponentInterfaceFilter, $first: Int, $last: Int) {
+  node(id: $component) {
+    ...on Component {
+      interfaces(
+        after: $after,
+        before: $before,
+        filterBy: $filterBy,
+        first: $first,
+        last: $last
+      ) {
+        totalCount
+        pageInfo {
+          hasNextPage
+          hasPreviousPage
+          startCursor
+          endCursor
+        }
+        nodes {
+          ...fInterfaceStub
+        }
+      }
+    }
+  }
+}
+
+query ListComponentConsumedInterfaces($component: ID!, $after: String, $before: String, $filterBy: ComponentInterfaceFilter, $first: Int, $last: Int) {
+  node(id: $component) {
+    ...on Component {
+      consumedInterfaces(
+        after: $after,
+        before: $before,
+        filterBy: $filterBy,
+        first: $first,
+        last: $last
+      ) {
+        totalCount
+        pageInfo {
+          hasNextPage
+          hasPreviousPage
+          startCursor
+          endCursor
+        }
+        nodes {
+          ...fInterfaceStub
+          component {
+            ...fComponentStub
+          }
+        }
+      }
+    }
+  }
+}
+
+query GetInterface($id: ID!) {
+  node(id: $id) {
+    ...on ComponentInterface {
+      ...fInterfaceStub
     }
   }
 }

--- a/src/app/dialogs/create-issue-dialog/create-issue-dialog.component.ts
+++ b/src/app/dialogs/create-issue-dialog/create-issue-dialog.component.ts
@@ -41,7 +41,7 @@ export class CreateIssueDialogComponent implements OnInit {
   selectedIssues: any = [];
   linkableProjectIssues: any = [];
 
-  selectableComponentInterfaces = this.data.component.node.interfaces.nodes;
+  selectableComponentInterfaces = []; // this.data.component.node.interfaces.nodes;
   selectedInterfaces = [];
   selectedAssignees = [];
   assignees = [{id: '0', name: 'user'}, {id: '2', name: 'zweiter User'}, {id: '3', name: 'dritter User'}];

--- a/src/app/interface-details/interface-details.component.html
+++ b/src/app/interface-details/interface-details.component.html
@@ -46,7 +46,7 @@
     <mat-tab label="Interface Issues">
       <div class="component-title">
         <h1>{{interface.name}}</h1>
-        <app-issue-list [listId]="issueListId"></app-issue-list>
+        <app-issue-list [projectId]="projectId" [listId]="issueListId"></app-issue-list>
       </div>
     </mat-tab>
   </mat-tab-group>

--- a/src/app/interface-details/interface-details.component.ts
+++ b/src/app/interface-details/interface-details.component.ts
@@ -23,6 +23,7 @@ export class InterfaceDetailsComponent implements OnInit {
   public interface$: Observable<GetComponentQuery>;
   private interface: GetComponentQuery;
   private interfaceId: string;
+  public projectId: string;
   public issueListId: ListId;
   public loading: boolean;
   public saveFailed: boolean;
@@ -38,6 +39,7 @@ export class InterfaceDetailsComponent implements OnInit {
               private route: ActivatedRoute,
               private notify: UserNotifyService) {
     this.editMode = false;
+    this.projectId = this.route.snapshot.paramMap.get('id');
     this.interfaceId = this.route.snapshot.paramMap.get('interfaceId');
     this.interface$ = this.interfaceStoreService.getInterface(this.interfaceId);
     this.interface$.subscribe(componentInterface => {

--- a/src/app/issue-list/issue-list.component.ts
+++ b/src/app/issue-list/issue-list.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { ComponentStoreService } from '@app/data/component/component-store.service';
 import { Subscription } from 'rxjs';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
@@ -140,7 +139,7 @@ export class IssueListComponent implements OnInit, OnDestroy {
       {
         data: {
           user: 'Component', name: this.component$.current.name, id: this.component$.current.id,
-          component: this.component$.current, projectId: this.projectId
+          component: { node: this.component$.current }, projectId: this.projectId
         }
       });
     createIssueDialogRef.afterClosed().subscribe(issueData => {

--- a/src/app/project-issue-list/project-issue-list.component.html
+++ b/src/app/project-issue-list/project-issue-list.component.html
@@ -13,6 +13,6 @@
 
   </div>
   <div class="component-title">
-    <app-issue-list [listId]="issueListId"></app-issue-list>
+    <app-issue-list [projectId]="projectId" [listId]="issueListId"></app-issue-list>
   </div>
 </div>


### PR DESCRIPTION
Put issues at /issues/:id instead of /component/:id/issue/:id because issues can be assigned to multiple locations, or none at all. Also moves more of issue-list to the declarative api.

Introduces a regression where issues can no longer be created on component interfaces. Planning on replacing issue creation in a follow-up PR anyway